### PR TITLE
Removed reference to non-embedded FontToolbox framework

### DIFF
--- a/Find Font Features.xcodeproj/project.pbxproj
+++ b/Find Font Features.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		B2539AA61CB6FA64002917DE /* OTFOutlineViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2539AA51CB6FA64002917DE /* OTFOutlineViewDelegate.swift */; };
 		B2539AA81CB7087A002917DE /* LDSwitchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2539AA71CB7087A002917DE /* LDSwitchButton.swift */; };
 		B2B0A2501F4AD2BD00D7E2CA /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2B0A24F1F4AD2BD00D7E2CA /* AppKit.framework */; };
-		B2E7D89320D3EBFE00823286 /* FontToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2B0A2511F4AD7C100D7E2CA /* FontToolbox.framework */; };
 		B2E7D89420D3EBFE00823286 /* FontToolbox.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B2B0A2511F4AD7C100D7E2CA /* FontToolbox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -61,7 +60,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2B0A2501F4AD2BD00D7E2CA /* AppKit.framework in Frameworks */,
-				B2E7D89320D3EBFE00823286 /* FontToolbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Thankfully, Xcode now puts in the required `@executable_path/../Frameworks` into Runpath Search Paths in the Build Settings. But what was causing the embedded framework not to be found was an additional reference to the external framework. The app was trying to load the external version first, and failing.